### PR TITLE
[SYM-4113] Make sure Firehose S3 bucket name is globally unique

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To provide the Sym Runtime with access to the resources created in this `Connect
 ```hcl
 module "kinesis_firehose_connector" {
   source  = "symopsio/kinesis-firehose-connector/sym"
-  version = ">= 1.0.0"
+  version = ">= 2.0.0"
 
   environment = "sandbox"
 }

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,10 @@ module "s3_bucket" {
   name               = "firehose-logs"
   namespace          = "sym"
   stage              = var.environment
+
+  # S3 Bucket names must be globally unique across all AWS accounts. Suffix a UUID to ensure uniqueness.
   bucket_name        = "${lower(var.name_prefix)}sym-firehose-logs-${var.environment}-${random_uuid.bucket_suffix.id}"
+
   additional_tag_map = var.tags
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,6 @@
 # Kinesis Firehose requires an S3 bucket to be set as a backup storage location
+resource "random_uuid" "bucket_suffix" {}
+
 module "s3_bucket" {
   source  = "cloudposse/s3-bucket/aws"
   version = "0.44.0"
@@ -10,7 +12,7 @@ module "s3_bucket" {
   name               = "firehose-logs"
   namespace          = "sym"
   stage              = var.environment
-  bucket_name        = "${lower(var.name_prefix)}sym-firehose-logs-${var.environment}"
+  bucket_name        = "${lower(var.name_prefix)}sym-firehose-logs-${var.environment}-${random_uuid.bucket_suffix.id}"
   additional_tag_map = var.tags
 }
 


### PR DESCRIPTION
# Summary
- S3 Bucket names must be globally unique, so we should append a UUID to end of the bucket name.


Note: This should be released as a major version update, as it will be a breaking change (bucket name changes will cause resource recreation)