### PR TITLE
Use Account ID for backup S3 bucket suffix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .idea/
 .vscode/
+
+.terraform/
+.terraform.lock.hcl

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 # Kinesis Firehose requires an S3 bucket to be set as a backup storage location
-resource "random_uuid" "bucket_suffix" {}
+data "aws_caller_identity" "current" {}
 
 module "s3_bucket" {
   source  = "cloudposse/s3-bucket/aws"
@@ -13,8 +13,8 @@ module "s3_bucket" {
   namespace          = "sym"
   stage              = var.environment
 
-  # S3 Bucket names must be globally unique across all AWS accounts. Suffix a UUID to ensure uniqueness.
-  bucket_name        = "${lower(var.name_prefix)}sym-firehose-logs-${var.environment}-${random_uuid.bucket_suffix.id}"
+  # S3 Bucket names must be globally unique across all AWS accounts. Suffix the account ID to ensure uniqueness
+  bucket_name        = "${lower(var.name_prefix)}sym-firehose-logs-${var.environment}-${data.aws_caller_identity.current.account_id}"
 
   additional_tag_map = var.tags
 }


### PR DESCRIPTION
S3 buckets have a 63 character naming limit, but also need to be globally unique across AWS Accounts.

PR#1 attempted to solve the unique naming issue by appending a UUID suffix, the UUID and `sym-firehose-logs-` take 54 characters, leaving only 9 characters for the environment and name prefix.

This PR changes the S3 bucket name to use the current account ID as S3 bucket suffix instead of a UUID

![Screen Shot 2022-09-12 at 10 23 24 AM](https://user-images.githubusercontent.com/10479740/189679883-ebe403d2-9fe0-4dd3-8352-8aa553161be0.png)
